### PR TITLE
Updated HaloMIFTiff to work with newer version of HALO

### DIFF
--- a/omeify/converters/raw2ometiff_converter.py
+++ b/omeify/converters/raw2ometiff_converter.py
@@ -62,7 +62,12 @@ class Raw2OmeTiffConverter:
 
         if self.logger.isEnabledFor(logging.INFO):
             self.logger.info("Executing raw2ometiff conversion...")
-        process = subprocess.run(cmd, check=True, stdout=stdout_setting, stderr=stderr_setting)
+            
+        #process = subprocess.run(cmd, check=True, stdout=stdout_setting, stderr=stderr_setting)
+        try:
+            process = subprocess.run(cmd, check=True, stdout=stdout_setting, stderr=stderr_setting)
+        except subprocess.CalledProcessError as e:
+            print(f"Command failed with exit code {e.returncode}: {e.stderr}")
 
         if self.logger.isEnabledFor(logging.WARNING) and process.stderr:
             self.logger.error(process.stderr.decode("utf-8"))

--- a/omeify/inputs/halo_mif_tiff.py
+++ b/omeify/inputs/halo_mif_tiff.py
@@ -60,11 +60,15 @@ class HaloMIFTiffImageFeatures(TiffImageFeatures):
     @property
     def size_c(self):
         # Implement the platform-specific logic for retrieving the size_c here
-        return len(self.report['series'][self.series]['levels'][0]['pages'])
+        #return len(self.report['series'][self.series]['levels'][0]['pages'])
+        return self.image_description['OME']\
+            ['Image']['Pixels']['@SizeC']
 
     @property
     def plane_count(self):
-        return len(self.report['series'][self.series]['levels'][0]['pages'])    
+        #return len(self.report['series'][self.series]['levels'][0]['pages'])
+        return self.image_description['OME']\
+            ['Image']['Pixels']['@SizeZ']
 
     # Override the channels property
     @property


### PR DESCRIPTION
When working with TMA images that were cropped in the new version of HALO, omeify wouldn't work. This updated some fields (SizeC, plane_count aka SizeZ)so it works again. 